### PR TITLE
Adding chardet to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-social-auth
 django-bootstrap3
 dj-static
 python-debian
+chardet


### PR DESCRIPTION
manage.py --help fails without chardet
