### PR TITLE
Support docker based package build

### DIFF
--- a/overcast/django/apps/buildsvc/pkgbuild/__init__.py
+++ b/overcast/django/apps/buildsvc/pkgbuild/__init__.py
@@ -54,16 +54,38 @@ class PackageBuilder(object):
         self.add_changelog_entry()
 
         if self.docker_build:
+            self.build_external_dependency_repo_keys()
+            self.build_external_dependency_repo_sources()
             self.docker_build_source_package()
             self.docker_build_binary_package()
         else:
             self.build_source_package()
             self.build_binary_packages()
 
+    def build_external_dependency_repo_keys(self):
+        """create a file which has all external dependency repos keys"""
+        extdeps = self.package_source.series.externaldependency_set.all()
+        if extdeps:
+            with open(os.path.join(self.basedir,'keys'), 'w') as fp:
+                for extdep in extdeps:
+                    if extdep.key:
+                        fp.write(extdep.key)
+
+
+    def build_external_dependency_repo_sources(self):
+        """create a file which has all external dependency repo sources"""
+        extdeps = self.package_source.series.externaldependency_set.all()
+        if extdeps:
+            with open(os.path.join(self.basedir,'repos'), 'w') as fp:
+                for extdep in extdeps:
+                    fp.write(extdep.deb_line)
+
+
     def docker_build_source_package(self):
         """Build source package in docker"""
         dbuild.docker_build(build_dir=self.basedir, build_type='source',
                             source_dir=self.buildir)
+
 
     def docker_build_binary_package(self):
         """Build binary packages in docker"""

--- a/overcast/django/apps/buildsvc/pkgbuild/__init__.py
+++ b/overcast/django/apps/buildsvc/pkgbuild/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import os.path
+import os
 import tempfile
 import dbuild
 
@@ -83,14 +83,15 @@ class PackageBuilder(object):
 
     def docker_build_source_package(self):
         """Build source package in docker"""
+        source_dir = os.path.basename(self.builddir)
         dbuild.docker_build(build_dir=self.basedir, build_type='source',
-                            source_dir=self.buildir)
+                            source_dir=source_dir, build_owner=os.getuid())
 
 
     def docker_build_binary_package(self):
         """Build binary packages in docker"""
         dbuild.docker_build(build_dir=self.basedir, build_type='binary',
-                            source_dir=self.buildir)
+                            build_owner=os.getuid())
 
     def build_binary_packages(self):
         dsc = filter(lambda s:s.endswith('.dsc'), os.listdir(self.basedir))[0]


### PR DESCRIPTION
This patch is to use python-dbuild to build the packages on docker container. In
order to work this, the system should have docker installed.
- This patch is not tested at this moment as I did not installed overcast.django locally on my machine for now.
- Currently use a branch of python-dbuild as that patch is not merged to master, which will be changed before this patch get merged.
- Also binary package build in this code use extra-repository etc which is not added in python-dbuild, so it is not supported at this moment.
- Disabled sbuild based builds - only docker based builds supported
- write docker_build stdout to build log - handling this in overcast code right
  now, until docker_build has a facility to stream logs
