### PR TITLE
Added possibility to override some settings in settings.py

### DIFF
--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -178,3 +178,10 @@ DEFAULT_FROM_EMAIL = 'noreply@aasemble.com'
 REST_AUTH_SERIALIZERS = {
     'USER_DETAILS_SERIALIZER': 'aasemble.django.apps.api.serializers.UserDetailsSerializer'
 }
+
+# Import local development server settings. settings_local is not present in git, not relevant for production deployment
+
+try:
+	from settings_local import *
+except ImportError as e:
+	pass

--- a/test_project/settings_local.template
+++ b/test_project/settings_local.template
@@ -1,0 +1,2 @@
+# This is the local development server settings file that overrides certain settings on main settings.py file
+


### PR DESCRIPTION
For local development environments, we can create a file called
settings_local.py in the same directory as settings.py that can
override settings in the main settings.py file.
