### PR TITLE
Add snapshots ui

### DIFF
--- a/aasemble/django/apps/main/templates/aasemble/base.html
+++ b/aasemble/django/apps/main/templates/aasemble/base.html
@@ -52,7 +52,7 @@
           </ul>
           <ul class="nav nav-sidebar">
             <li><a href="{% url "mirrorsvc:mirrors" %}">Mirrors</a></li>
-            <li><a href="">Snapshots</a></li>
+            <li><a href="{% url "mirrorsvc:snapshots" %}">Snapshots</a></li>
           </ul>
         </div>
         <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">

--- a/aasemble/django/apps/mirrorsvc/migrations/0009_mirrorset_extra_admins.py
+++ b/aasemble/django/apps/mirrorsvc/migrations/0009_mirrorset_extra_admins.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0006_require_contenttypes_0002'),
+        ('mirrorsvc', '0008_mirror_extra_admins'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='mirrorset',
+            name='extra_admins',
+            field=models.ManyToManyField(to='auth.Group'),
+        ),
+    ]

--- a/aasemble/django/apps/mirrorsvc/models.py
+++ b/aasemble/django/apps/mirrorsvc/models.py
@@ -15,6 +15,15 @@ class MirrorSet(models.Model):
     name = models.CharField(max_length=100)
     owner = models.ForeignKey(auth_models.User)
     mirrors = models.ManyToManyField('Mirror')
+    extra_admins = models.ManyToManyField(auth_models.Group)
+
+    @classmethod
+    def lookup_by_user(cls, user):
+        if not user.is_active:
+            return cls.objects.none()
+        if user.is_superuser:
+            return cls.objects.all()
+        return cls.objects.filter(owner=user) | cls.objects.filter(extra_admins=user.groups.all())
 
 
 @python_2_unicode_compatible

--- a/aasemble/django/apps/mirrorsvc/templates/mirrorsvc/html/mirrors.html
+++ b/aasemble/django/apps/mirrorsvc/templates/mirrorsvc/html/mirrors.html
@@ -3,7 +3,6 @@
 
 {% block title %}Mirrors{% endblock %}
 {% block aasemble_content %}
-  {% for mirror in mirrors %}
   <div class="table-responsive">
     <table class="table table-striped">
       <thead>
@@ -16,6 +15,7 @@
         </tr>
       </thead>
       <tbody>
+      {% for mirror in mirrors %}
         <tr>
           <td><a href="{{ mirror.url }}">{{ mirror.url }}</a></td>
           <td>{{ mirror.series }}</td>
@@ -23,8 +23,8 @@
           <td>{{ mirror.public }}</td>
           <td>{{ mirror.refresh_in_progress }}</td>
         </tr>
+      {% endfor %}
       </tbody>
     </table>
   </div>
-  {% endfor %}
 {% endblock %}

--- a/aasemble/django/apps/mirrorsvc/templates/mirrorsvc/html/snapshots.html
+++ b/aasemble/django/apps/mirrorsvc/templates/mirrorsvc/html/snapshots.html
@@ -7,7 +7,7 @@
     <table class="table table-striped">
       <thead>
         <tr>
-          <th>MirrorSet</th>
+          <th>Snapshot MirrorSet</th>
           <th>Time Created</th>
         </tr>
       </thead>

--- a/aasemble/django/apps/mirrorsvc/templates/mirrorsvc/html/snapshots.html
+++ b/aasemble/django/apps/mirrorsvc/templates/mirrorsvc/html/snapshots.html
@@ -1,0 +1,24 @@
+{% extends 'aasemble/base.html' %}
+{% load bootstrap3 %}
+
+{% block title %}Snapshots{% endblock %}
+{% block aasemble_content %}
+  <div class="table-responsive">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>MirrorSet</th>
+          <th>Time Created</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for snapshot in snapshots %}
+        <tr>
+          <td>{{ snapshot.mirrorset.name }}</td>
+          <td>{{ snapshot.timestamp }}</td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endblock %}

--- a/aasemble/django/apps/mirrorsvc/urls.py
+++ b/aasemble/django/apps/mirrorsvc/urls.py
@@ -2,4 +2,5 @@ from django.conf.urls import include, url
 
 urlpatterns = [
     url(r'^mirrors/', 'aasemble.django.apps.mirrorsvc.views.mirrors', name='mirrors'),
+    url(r'^snapshots/', 'aasemble.django.apps.mirrorsvc.views.snapshots', name='snapshots'),
 ]

--- a/aasemble/django/apps/mirrorsvc/views.py
+++ b/aasemble/django/apps/mirrorsvc/views.py
@@ -14,6 +14,12 @@ def mirrors(request):
     return render(request, 'mirrorsvc/html/mirrors.html',
                   {'mirrors': mirrors})
 
+@login_required
+def snapshots(request):
+    snapshots = Snapshot.objects.filter(mirrorset__in=MirrorSet.lookup_by_user(request.user)).order_by('timestamp')
+    return render(request, 'mirrorsvc/html/snapshots.html',
+                  {'snapshots': snapshots})
+
 #############
 # API stuff #
 #############


### PR DESCRIPTION
- Made a migration to add extra_admins field to MirrorSet
- Fixed a small issue with for loop, will now always show table header
  for mirrors
- Changed heading from MirrorSet to Snapshot MirrorSet
- Added snapshots UI to view snapshots by:
- Updated base.html snapshots url link
- Added lookup_by_user class method to MirrorSet
- Added snapshots.html template
- Added snap hosts url to urls.py
- Added snapshots method to return snapshots
