### PR TITLE
Pass callables to url() rather than their name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   - DJANGO_VERSION=1.8
   - DJANGO_VERSION=1.9b1
 install:
-  - "pip install -U pip"
-  - "pip install -U Django=$DJANGO_VERSION"
-  - "pip install -r requirements.txt"
+  - pip install -U pip
+  - pip install -U Django==$DJANGO_VERSION
+  - pip install -r requirements.txt
 script: "python manage.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,11 @@ language: python
 python:
   - "2.7"
   - "3.4"
-install: "pip install -r requirements.txt"
+env:
+  - DJANGO_VERSION=1.8
+  - DJANGO_VERSION=1.9b1
+install:
+  - "pip install -U pip"
+  - "pip install -U Django=$DJANGO_VERSION"
+  - "pip install -r requirements.txt"
 script: "python manage.py test"

--- a/aasemble/django/apps/buildsvc/urls.py
+++ b/aasemble/django/apps/buildsvc/urls.py
@@ -1,8 +1,10 @@
 from django.conf.urls import include, url
 
+import aasemble.django.apps.buildsvc.views
+
 urlpatterns = [
-    url(r'^sources/(?P<source_id>\d+|new)/', 'aasemble.django.apps.buildsvc.views.package_source', name='package_source'),
-    url(r'^sources/', 'aasemble.django.apps.buildsvc.views.sources', name='sources'),
-    url(r'^repositories/', 'aasemble.django.apps.buildsvc.views.repositories', name='repositories'),
-    url(r'^builds/', 'aasemble.django.apps.buildsvc.views.builds', name='builds'),
+    url(r'^sources/(?P<source_id>\d+|new)/', aasemble.django.apps.buildsvc.views.package_source, name='package_source'),
+    url(r'^sources/', aasemble.django.apps.buildsvc.views.sources, name='sources'),
+    url(r'^repositories/', aasemble.django.apps.buildsvc.views.repositories, name='repositories'),
+    url(r'^builds/', aasemble.django.apps.buildsvc.views.builds, name='builds'),
 ]

--- a/aasemble/django/apps/mirrorsvc/urls.py
+++ b/aasemble/django/apps/mirrorsvc/urls.py
@@ -1,6 +1,8 @@
 from django.conf.urls import include, url
 
+import aasemble.django.apps.mirrorsvc.views
+
 urlpatterns = [
-    url(r'^mirrors/', 'aasemble.django.apps.mirrorsvc.views.mirrors', name='mirrors'),
-    url(r'^snapshots/', 'aasemble.django.apps.mirrorsvc.views.snapshots', name='snapshots'),
+    url(r'^mirrors/', aasemble.django.apps.mirrorsvc.views.mirrors, name='mirrors'),
+    url(r'^snapshots/', aasemble.django.apps.mirrorsvc.views.snapshots, name='snapshots'),
 ]

--- a/test_project/urls.py
+++ b/test_project/urls.py
@@ -1,13 +1,16 @@
 from django.conf.urls import include, url
 from django.contrib import admin
+import django.contrib.auth.views
+import aasemble.django.apps.main.views
+
 
 urlpatterns = [
     url(r'^api/', include('aasemble.django.apps.api.urls')),
     url(r'^accounts/', include('allauth.urls')),
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^profile/$', 'aasemble.django.apps.main.views.profile', name='profile'),
-    url(r'^$', 'aasemble.django.apps.main.views.index', name='index'),
+    url(r'^profile/$', aasemble.django.apps.main.views.profile, name='profile'),
+    url(r'^$', aasemble.django.apps.main.views.index, name='index'),
     url(r'^buildsvc/', include('aasemble.django.apps.buildsvc.urls', namespace='buildsvc')),
     url(r'^mirrorsvc/', include('aasemble.django.apps.mirrorsvc.urls', namespace='mirrorsvc')),
-    url(r'^logout/', 'django.contrib.auth.views.logout', {'next_page': '/'}, name='logout'),
+    url(r'^logout/', django.contrib.auth.views.logout, {'next_page': '/'}, name='logout'),
 ]


### PR DESCRIPTION
Django 1.9 complains and Django 1.10 will require it
