### PR TITLE
Wrapper classes has been added for serving api Req.

### DIFF
--- a/aasemble/django/apps/api/base.py
+++ b/aasemble/django/apps/api/base.py
@@ -1,0 +1,4 @@
+from rest_framework.test import APITestCase
+
+class APIv1Tests(APITestCase):
+    fixtures = ['data.json', 'data2.json']

--- a/aasemble/django/service/client/auth_client.py
+++ b/aasemble/django/service/client/auth_client.py
@@ -1,0 +1,7 @@
+from aasemble.django.apps.api import base
+
+class AuthClient(base.APIv1Tests):
+    list_url = '/api/v1/auth/user/'
+    def get_auth(self):
+        response = self.client.get(self.list_url)
+        return response

--- a/aasemble/django/service/client/build_client.py
+++ b/aasemble/django/service/client/build_client.py
@@ -1,0 +1,9 @@
+from aasemble.django.apps.api import base
+
+class BuildClient(base.APIv1Tests):
+    list_url = '/api/v1/builds/'
+    fixtures = ['data.json', 'data2.json', 'repository.json']
+    def get_build(self):
+        response = self.client.get(self.list_url)
+        return response
+

--- a/aasemble/django/service/client/repository_client.py
+++ b/aasemble/django/service/client/repository_client.py
@@ -1,0 +1,34 @@
+from aasemble.django.apps.api import base
+
+class RepositoryClient(base.APIv1Tests):
+    list_url = '/api/v1/repositories/'
+    def create_repository(self, **kwargs):
+        params = {}
+        for option in kwargs:
+            value = kwargs.get(option)
+            if isinstance(value, dict) or isinstance(value, tuple):
+                params.update(value)
+            else:
+                params[option] = value
+        response = self.client.post(self.list_url, params, format='json')
+        return response
+    def show_repository(self, repo_id):
+        response = self.client.get(repo_id)
+        return response
+    def get_repository(self):
+        response = self.client.get(self.list_url)
+        return response
+    def delete_repository(self, repo_id):
+        response = self.client.delete(repo_id)
+        return response
+    def update_repository(self,repo_id, **kwargs):
+        params = {}
+        for option in kwargs:
+            value = kwargs.get(option)
+            if isinstance(value, dict) or isinstance(value, tuple):
+                params.update(value)
+            else:
+                params[option] = value
+        response = self.client.patch(repo_id, params, format='json')
+        return response
+

--- a/aasemble/django/service/client/source_client.py
+++ b/aasemble/django/service/client/source_client.py
@@ -1,0 +1,25 @@
+from aasemble.django.apps.api import base
+
+class SourceClient(base.APIv1Tests):
+    list_url = '/api/v1/sources/'
+    fixtures = ['data.json', 'data2.json', 'repository.json']
+    def create_source(self, **kwargs):
+        params = {}
+        for option in kwargs:
+            value = kwargs.get(option)
+            if isinstance(value, dict) or isinstance(value, tuple):
+                params.update(value)
+            else:
+                params[option] = value
+        response = self.client.post(self.list_url, params, format='json')
+        return response
+    def show_source(self, repo_id):
+        response = self.client.get(repo_id)
+        return response
+    def get_source(self,uri=list_url):
+        response = self.client.get(uri)
+        return response
+    def delete_source(self, repo_id):
+        response = self.client.delete(repo_id)
+        return response
+


### PR DESCRIPTION
Wrapper classes has been added for following data types:
- Sources
- Repositories
- Builds
- Auth
  Presently these wrapper classes only have methods that are covered in test.py

This change is done so as to create abstraction from raw api request
to main test case writing. From service clients we are calling the http methods
and after getting the results, passing it to original test case.

TBD: Further going we will be doing some basic sanity checks on api response
in service client which will be common to all test cases and in test.py only
test case specific validations are done.
