### PR TITLE
Accept any kwargs in the mirror refresh view

### DIFF
--- a/aasemble/django/apps/api/v2/views.py
+++ b/aasemble/django/apps/api/v2/views.py
@@ -48,7 +48,7 @@ class MirrorViewSet(viewsets.ModelViewSet):
         serializer.save(owner=self.request.user)
 
     @detail_route(methods=['post'])
-    def refresh(self, request, pk=None):
+    def refresh(self, request, **kwargs):
         mirror = self.get_object()
         scheduled = mirror.schedule_update_mirror()
         if scheduled:


### PR DESCRIPTION
We don't handle them directly anyway, but rather let the get_object
method do the hard work.
