### PR TITLE
Added create-mirror-UI

### DIFF
--- a/aasemble/django/apps/mirrorsvc/forms.py
+++ b/aasemble/django/apps/mirrorsvc/forms.py
@@ -1,0 +1,8 @@
+from django.forms import ModelForm
+from aasemble.django.apps.mirrorsvc.models import Mirror
+
+
+class MirrorDefinitionForm(ModelForm):
+    class Meta:
+        model = Mirror
+        fields = ['url', 'series', 'components', 'public']

--- a/aasemble/django/apps/mirrorsvc/models.py
+++ b/aasemble/django/apps/mirrorsvc/models.py
@@ -10,6 +10,7 @@ from django.db import models
 from django.template.loader import render_to_string
 from django.utils.encoding import python_2_unicode_compatible
 from django.core.urlresolvers import reverse
+from django.forms import ModelForm
 
 from . import tasks
 
@@ -160,3 +161,9 @@ class Snapshot(models.Model):
     def perform_snapshot(self):
         self.sync_dists()
         self.symlink_pool()
+
+
+class MirrorDefinitionForm(ModelForm):
+    class Meta:
+        model = Mirror
+        fields = ['url', 'series', 'components', 'public']

--- a/aasemble/django/apps/mirrorsvc/models.py
+++ b/aasemble/django/apps/mirrorsvc/models.py
@@ -160,5 +160,3 @@ class Snapshot(models.Model):
     def perform_snapshot(self):
         self.sync_dists()
         self.symlink_pool()
-
-

--- a/aasemble/django/apps/mirrorsvc/models.py
+++ b/aasemble/django/apps/mirrorsvc/models.py
@@ -10,7 +10,6 @@ from django.db import models
 from django.template.loader import render_to_string
 from django.utils.encoding import python_2_unicode_compatible
 from django.core.urlresolvers import reverse
-from django.forms import ModelForm
 
 from . import tasks
 
@@ -163,7 +162,3 @@ class Snapshot(models.Model):
         self.symlink_pool()
 
 
-class MirrorDefinitionForm(ModelForm):
-    class Meta:
-        model = Mirror
-        fields = ['url', 'series', 'components', 'public']

--- a/aasemble/django/apps/mirrorsvc/templates/mirrorsvc/html/mirror_definition.html
+++ b/aasemble/django/apps/mirrorsvc/templates/mirrorsvc/html/mirror_definition.html
@@ -1,0 +1,25 @@
+{% extends 'aasemble/base.html' %}
+{% load bootstrap3 %}
+{% block title %}
+    {% if mirror_id != 'new' %}
+        Edit Mirror
+    {% else %}
+        Add new Mirror
+    {% endif %}
+{% endblock %}
+{% block aasemble_content %}
+<form action="{% url "mirrorsvc:mirror_definition" mirror_id=mirror_id %}" method="post">
+    {% csrf_token %}
+    {% bootstrap_form form layout='inline' %}
+    {% buttons %}
+        <button type="submit" class="btn btn-primary">
+            {% bootstrap_icon "star" %} Submit
+        </button>
+        {% if mirror_id != 'new' %}
+            <button type="submit" class="btn btn-danger" name="delete" value="delete">
+                 Delete
+            </button>
+        {% endif %}
+    {% endbuttons %}
+{% endblock %}
+

--- a/aasemble/django/apps/mirrorsvc/templates/mirrorsvc/html/mirrors.html
+++ b/aasemble/django/apps/mirrorsvc/templates/mirrorsvc/html/mirrors.html
@@ -7,6 +7,7 @@
     <table class="table table-striped">
       <thead>
         <tr>
+          <th>UUID</th>
           <th>URL</th>
           <th>Series</th>
           <th>Components</th>
@@ -17,6 +18,7 @@
       <tbody>
       {% for mirror in mirrors %}
         <tr>
+          <td>{{ mirror.uuid }}</td>
           <td><a href="{{ mirror.url }}">{{ mirror.url }}</a></td>
           <td>{{ mirror.series }}</td>
           <td>{{ mirror.components }}</td>

--- a/aasemble/django/apps/mirrorsvc/templates/mirrorsvc/html/mirrors.html
+++ b/aasemble/django/apps/mirrorsvc/templates/mirrorsvc/html/mirrors.html
@@ -27,4 +27,5 @@
       </tbody>
     </table>
   </div>
+    <a class="btn btn-primary" href="{% url "mirrorsvc:mirror_definition" mirror_id='new' %}" role="button">{% bootstrap_icon "plus" %} New</a>
 {% endblock %}

--- a/aasemble/django/apps/mirrorsvc/urls.py
+++ b/aasemble/django/apps/mirrorsvc/urls.py
@@ -3,6 +3,8 @@ from django.conf.urls import url
 import aasemble.django.apps.mirrorsvc.views
 
 urlpatterns = [
+    url(r'^mirrors/(?P<mirror_id>\d+|new)/', aasemble.django.apps.mirrorsvc.views.mirror_definition,
+        name='mirror_definition'),  # Added before mirrors/ to override next line
     url(r'^mirrors/', aasemble.django.apps.mirrorsvc.views.mirrors, name='mirrors'),
     url(r'^snapshots/', aasemble.django.apps.mirrorsvc.views.snapshots, name='snapshots'),
     url(r'^mirrorsets/(?P<uuid>[^/]+)/snapshots/', aasemble.django.apps.mirrorsvc.views.mirrorset_snapshots, name='mirrorset_snapshots'),

--- a/aasemble/django/apps/mirrorsvc/views.py
+++ b/aasemble/django/apps/mirrorsvc/views.py
@@ -6,6 +6,7 @@ from django.http import HttpResponseRedirect
 from .models import Mirror, MirrorSet, Snapshot
 from .forms import MirrorDefinitionForm
 
+
 def get_mirror_definition_form(request, *args, **kwargs):
     form = MirrorDefinitionForm(*args, **kwargs)
     return form

--- a/aasemble/django/apps/mirrorsvc/views.py
+++ b/aasemble/django/apps/mirrorsvc/views.py
@@ -1,8 +1,44 @@
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
+from django.core.urlresolvers import reverse
+from django.http import HttpResponseRedirect
 
-from .models import Mirror, MirrorSet, Snapshot
+from .models import Mirror, MirrorSet, Snapshot, MirrorDefinitionForm
 
+
+def get_mirror_definition_form(request, *args, **kwargs):
+    form = MirrorDefinitionForm(*args, **kwargs)
+    return form
+
+@login_required
+def mirror_definition(request, mirror_id):
+    # print("entered mirror_definition function")
+    if mirror_id == 'new':
+        print("mirror_id==new")
+        mirror = None
+    else:
+        mirror = Mirror.objects.get(pk=mirror_id)
+        if not mirror.user_can_modify(request.user):
+            mirror, mirror_id = None, 'new'
+
+    if request.method == 'POST':
+        print("Entered request.method == POST")
+        form = get_mirror_definition_form(request, request.POST, instance=mirror)
+
+        if mirror is not None and request.POST.get('delete', '') == 'delete':
+            mirror.delete()
+            return HttpResponseRedirect(reverse('mirrorsvc:mirrors'))
+
+        if form.is_valid():
+            new_mirror = form.save(commit=False)
+            new_mirror.owner = request.user
+            new_mirror.save()
+            return HttpResponseRedirect(reverse('mirrorsvc:mirrors'))
+    else:
+        form = get_mirror_definition_form(request, instance=mirror)
+
+    return render(request, 'mirrorsvc/html/mirror_definition.html',
+                  {'form': form, 'mirror_id': mirror_id})
 
 @login_required
 def mirrors(request):

--- a/aasemble/django/apps/mirrorsvc/views.py
+++ b/aasemble/django/apps/mirrorsvc/views.py
@@ -10,6 +10,7 @@ def get_mirror_definition_form(request, *args, **kwargs):
     form = MirrorDefinitionForm(*args, **kwargs)
     return form
 
+
 @login_required
 def mirror_definition(request, mirror_id):
     # print("entered mirror_definition function")
@@ -39,6 +40,7 @@ def mirror_definition(request, mirror_id):
 
     return render(request, 'mirrorsvc/html/mirror_definition.html',
                   {'form': form, 'mirror_id': mirror_id})
+
 
 @login_required
 def mirrors(request):

--- a/aasemble/django/apps/mirrorsvc/views.py
+++ b/aasemble/django/apps/mirrorsvc/views.py
@@ -3,8 +3,8 @@ from django.shortcuts import render
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 
-from .models import Mirror, MirrorSet, Snapshot, MirrorDefinitionForm
-
+from .models import Mirror, MirrorSet, Snapshot
+from .forms import MirrorDefinitionForm
 
 def get_mirror_definition_form(request, *args, **kwargs):
     form = MirrorDefinitionForm(*args, **kwargs)


### PR DESCRIPTION
Instead of API, a user can now also create a mirror with a UI
- Added MirrorDefinitionForm to models
- Added new Mirror definition template
- Added New button to mirrors.html
- Added url for new mirror to urls.py
- Added mirror_definition function to views.py
