### PR TITLE
Add feature to view and go to last commit

### DIFF
--- a/aasemble/django/apps/buildsvc/templates/buildsvc/html/sources.html
+++ b/aasemble/django/apps/buildsvc/templates/buildsvc/html/sources.html
@@ -19,11 +19,15 @@
         <tr>
           <td><small><a href="{% url "buildsvc:package_source" source_id=source.id %}">{% bootstrap_icon "pencil" %}</a></small></td>
           <td><a href="{{ source.git_url }}">{{ source.git_url }}</a></td>
-          <td><a href="{{ source.github_repository.url }}/tree/{{ source.branch }}">{{ source.branch }}</a></td>
+          <td><a href="{{ source.git_url }}/tree/{{ source.branch }}">{{ source.branch }}</a></td>
           <td><a href="#">{{ source.series }}</a></td>
-          {% with source.git_url|add:"/commit/"|add:source.last_built_version as last_built_commit_url %}
-          <td><a href="{{ last_built_commit_url }}">{{ source.last_built_version }}</a></td>
-          {% endwith %}
+          {% if source.last_built_version == None %}
+              <td>None</td>
+          {% else %}
+              {% with source.git_url|add:"/commit/"|add:source.last_built_version as last_built_commit_url %}
+              <td><a href="{{ last_built_commit_url }}">{{ source.last_built_version }}</a></td>
+              {% endwith %}
+          {% endif %}
         </tr>
         {% endfor %}
       </tbody>

--- a/aasemble/django/apps/buildsvc/templates/buildsvc/html/sources.html
+++ b/aasemble/django/apps/buildsvc/templates/buildsvc/html/sources.html
@@ -11,6 +11,7 @@
           <th>Repository</th>
           <th>Branch</th>
           <th>Destination APT repo</th>
+          <th>Last built commit</th>
         </tr>
       </thead>
       <tbody>
@@ -20,6 +21,9 @@
           <td><a href="{{ source.git_url }}">{{ source.git_url }}</a></td>
           <td><a href="{{ source.github_repository.url }}/tree/{{ source.branch }}">{{ source.branch }}</a></td>
           <td><a href="#">{{ source.series }}</a></td>
+          {% with source.git_url|add:"/commit/"|add:source.last_built_version as last_built_commit_url %}
+          <td><a href="{{ last_built_commit_url }}">{{ source.last_built_version }}</a></td>
+          {% endwith %}
         </tr>
         {% endfor %}
       </tbody>


### PR DESCRIPTION
Now the user can directly go to the last built commit and view the code
that was packaged on GitHub.
