### PR TITLE
Fixed issue with showing commit SHA

### DIFF
--- a/aasemble/django/apps/buildsvc/templates/buildsvc/html/sources.html
+++ b/aasemble/django/apps/buildsvc/templates/buildsvc/html/sources.html
@@ -21,11 +21,11 @@
           <td><a href="{{ source.git_url }}">{{ source.git_url }}</a></td>
           <td><a href="{{ source.git_url }}/tree/{{ source.branch }}">{{ source.branch }}</a></td>
           <td><a href="#">{{ source.series }}</a></td>
-          {% if source.last_built_version == None %}
+          {% if source.last_seen_revision == None %}
               <td>None</td>
           {% else %}
-              {% with source.git_url|add:"/commit/"|add:source.last_built_version as last_built_commit_url %}
-              <td><a href="{{ last_built_commit_url }}">{{ source.last_built_version }}</a></td>
+              {% with source.git_url|add:"/commit/"|add:source.last_seen_revision as last_commit_url %}
+              <td><a href="{{ last_commit_url }}">{{ source.last_seen_revision }}</a></td>
               {% endwith %}
           {% endif %}
         </tr>


### PR DESCRIPTION
Now showing the commit SHA instead of version number.
