### PR TITLE
Replace test user with someone who has access to multiple groups

### DIFF
--- a/aasemble/django/apps/api/tests.py
+++ b/aasemble/django/apps/api/tests.py
@@ -20,9 +20,9 @@ class APIv1RepositoryTests(APIv1Tests):
     list_url = '/api/v1/repositories/'
 
     def test_fetch_sources(self):
-        # Use alterego2 to make sure it works with users who are members
+        # Use user brandon to make sure it works with users who are members
         # of multiple groups
-        authenticate(self.client, 'eric')
+        authenticate(self.client, 'brandon')
         response = self.client.get(self.list_url)
 
         for repo in response.data['results']:

--- a/aasemble/django/apps/api/tests.py
+++ b/aasemble/django/apps/api/tests.py
@@ -30,9 +30,9 @@ class APIv1RepositoryTests(APIv1Tests):
             self.assertEquals(resp.status_code, 200)
 
     def test_fetch_external_dependencies(self):
-        # Use alterego2 to make sure it works with users who are members
+        # Use brandon to make sure it works with users who are members
         # of multiple groups
-        authenticate(self.client, 'eric')
+        authenticate(self.client, 'brandon')
         response = self.client.get(self.list_url)
 
         for repo in response.data['results']:


### PR DESCRIPTION
Now test_fetch_sources will user user brandon who is a member of
multiple groups, to ensure the API fetches sources properly.
