### PR TITLE
Use fixed drf-nested-routers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ django-celery
 dj-static
 python-debian
 djangorestframework
-git+https://github.com/alanjds/drf-nested-routers
+git+https://github.com/sorenh/drf-nested-routers@escape-regexes#egg=drf-nested-routers
 chardet
 pytz
 mysqlclient


### PR DESCRIPTION
The newest version of drf-nested-routers caused lookup_value_regex with '{X}' in it to break in a few different ways. Patch submitted upstream. Until it lands, use my branch.
