### PR TITLE
Remove caching, use select_related from view instead

### DIFF
--- a/aasemble/django/apps/api/tests.py
+++ b/aasemble/django/apps/api/tests.py
@@ -246,7 +246,10 @@ class APIv1Tests(APITestCase):
 
     def test_fetch_builds(self):
         authenticate(self.client, 'eric')
-        response = self.client.get(self.build_list_url)
+        # 3 queries: Authenticate, count results, fetch results
+        with self.assertNumQueries(3):
+            response = self.client.get(self.build_list_url)
+
         self.assertEquals(response.status_code, 200)
         self.assertEquals(response.data['count'], 10)
 

--- a/aasemble/django/apps/api/v1/views.py
+++ b/aasemble/django/apps/api/v1/views.py
@@ -197,7 +197,7 @@ class aaSembleV1Views(object):
             """
             lookup_field = selff.default_lookup_field
             lookup_value_regex = selff.default_lookup_value_regex
-            queryset = buildsvc_models.BuildRecord.objects.all()
+            queryset = buildsvc_models.BuildRecord.objects.all().select_related('source__series__repository__user')
             serializer_class = selff.serializers.BuildRecordSerializer
 
             def get_queryset(self):

--- a/aasemble/django/apps/buildsvc/models.py
+++ b/aasemble/django/apps/buildsvc/models.py
@@ -427,20 +427,8 @@ class BuildRecord(models.Model):
 
         return path
 
-    @property
-    def base_url(self):
-        cache_key = 'source_%s_base_url' % (self.source_id,)
-
-        val = cache.get(cache_key)
-
-        if val is None:
-            val = self.source.series.repository.base_url
-            cache.set(cache_key, val, 5)
-
-        return val
-
     def buildlog_url(self):
-        return '%s/buildlogs/%s' % (self.base_url, self.logpath())
+        return '%s/buildlogs/%s' % (self.source.series.repository.base_url, self.logpath())
 
 
 @python_2_unicode_compatible

--- a/aasemble/django/apps/buildsvc/models.py
+++ b/aasemble/django/apps/buildsvc/models.py
@@ -11,7 +11,6 @@ import deb822
 
 from django.conf import settings
 from django.contrib.auth import models as auth_models
-from django.core.cache import cache
 from django.db import models
 from django.forms import ModelForm
 from django.template.loader import render_to_string


### PR DESCRIPTION
Gets the number of requests down to 3 from 31 just during testing. In real life, it's down to three from hundreds.
