### PR TITLE
Updated fixture so that all the data for model "buildsvc.packagesource" are placed in sequential order.

### DIFF
--- a/aasemble/django/apps/api/fixtures/complete.json
+++ b/aasemble/django/apps/api/fixtures/complete.json
@@ -795,6 +795,20 @@
 },
 {
     "fields": {
+        "last_seen_revision": null,
+        "last_built_version": null,
+        "uuid": "b161fde2-4d8d-4f4a-8a73-1aeb5c99d478",
+        "series": 8,
+        "last_built_name": null,
+        "build_counter": 0,
+        "git_url": "https://github.com/eric/project11",
+        "branch": "master"
+    },
+    "model": "buildsvc.packagesource",
+    "pk": 12
+},
+{
+    "fields": {
         "uuid": "1dcc86aa-c925-49b0-9f1e-ffe6839150b7",
         "source": 1,
         "build_started": "2015-11-20T11:37:41.147Z",
@@ -912,20 +926,6 @@
     },
     "model": "buildsvc.buildrecord",
     "pk": 10
-},
-{
-    "fields": {
-        "last_seen_revision": null,
-        "last_built_version": null,
-        "uuid": "b161fde2-4d8d-4f4a-8a73-1aeb5c99d478",
-        "series": 8,
-        "last_built_name": null,
-        "build_counter": 0,
-        "git_url": "https://github.com/eric/project11",
-        "branch": "master"
-    },
-    "model": "buildsvc.packagesource",
-    "pk": 12
 },
 {
     "fields": {


### PR DESCRIPTION
Currently data for model": "buildsvc.repository",  "pk": 12 is stored  in between Model "buildsvc.repository". I have moved it so that data for buildsvc.packagesource model is placed in sequential order. 
