### PR TITLE
Add django-rest-framework tracking

### DIFF
--- a/aasemble/django/apps/api/tests.py
+++ b/aasemble/django/apps/api/tests.py
@@ -595,8 +595,11 @@ class APIv1Tests(APITestCase):
     @mock.patch('aasemble.django.apps.mirrorsvc.tasks.refresh_mirror')
     def test_refresh_mirror(self, refresh_mirror):
         mirror = self.test_create_mirror()
-        self.client.post(mirror['self'] + 'refresh/')
+        response = self.client.post(mirror['self'] + 'refresh/')
         self.assertTrue(refresh_mirror.delay.call_args_list)
+        self.assertEquals(response.data['status'], 'update scheduled')
+        response = self.client.post(mirror['self'] + 'refresh/')
+        self.assertEquals(response.data['status'], 'update already scheduled')
 
     def test_get_correct_mirror_for_user(self):
         self.test_create_mirror()
@@ -609,14 +612,6 @@ class APIv1Tests(APITestCase):
         response = self.client.get(self.mirror_list_url)
         self.assertEquals(len(response.data['results']), 1, 'did not return only 1 mirror')
         self.assertEquals(response.data['results'][0]['url'], 'http://example2.com/', 'url not the same as created')
-
-    @mock.patch('aasemble.django.apps.mirrorsvc.tasks.refresh_mirror')
-    def test_refresh_mirror_status(self, refresh_mirror):
-        mirror = self.test_create_mirror()
-        response = self.client.post(mirror['self'] + 'refresh/')
-        self.assertEquals(response.data['status'], 'update scheduled')
-        response = self.client.post(mirror['self'] + 'refresh/')
-        self.assertEquals(response.data['status'], 'update already scheduled')
 
     ####################
     # Mirror set tests #

--- a/aasemble/django/apps/api/tests.py
+++ b/aasemble/django/apps/api/tests.py
@@ -523,7 +523,7 @@ class APIv1Tests(APITestCase):
     def test_patch_public_mirror_deactivated_other_user(self):
         mirror = self.test_patch_mirror()
         data = {'public': False}
-        authenticate(self.client, 'harold')
+        authenticate(self.client, 'frank')
         response = self.client.patch(mirror['self'], data, format='json')
         self.assertEquals(response.status_code, 401)
         self.assertEquals(response.data, {'detail': 'User inactive or deleted.'})
@@ -531,7 +531,7 @@ class APIv1Tests(APITestCase):
     def test_patch_public_mirror_deactivated_super_user(self):
         mirror = self.test_patch_mirror()
         data = {'public': False}
-        authenticate(self.client, 'frank')
+        authenticate(self.client, 'harold')
         response = self.client.patch(mirror['self'], data, format='json')
         self.assertEquals(response.status_code, 401)
         self.assertEquals(response.data, {'detail': 'User inactive or deleted.'})

--- a/aasemble/django/apps/api/v1/views.py
+++ b/aasemble/django/apps/api/v1/views.py
@@ -14,6 +14,8 @@ from rest_framework.response import Response
 
 from rest_framework_nested import routers
 
+from rest_framework_tracking.mixins import LoggingMixin
+
 from aasemble.django.apps.buildsvc import models as buildsvc_models
 from aasemble.django.apps.mirrorsvc import models as mirrorsvc_models
 from aasemble.django.exceptions import DuplicateResourceException
@@ -45,7 +47,7 @@ class aaSembleV1Views(object):
         self.urls = self.build_urls()
 
     def MirrorViewSetFactory(selff):
-        class MirrorViewSet(viewsets.ModelViewSet):
+        class MirrorViewSet(LoggingMixin, viewsets.ModelViewSet):
             """
             API endpoint that allows mirrors to be viewed or edited.
             """

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ django-allauth
 redis
 django-bootstrap3
 github3.py
+git+https://github.com/mayankkapoor/drf-tracking

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = (
     'allauth.account',
     'allauth.socialaccount',
     'allauth.socialaccount.providers.github',
+    'rest_framework_tracking'
 )
 
 MIDDLEWARE_CLASSES = (


### PR DESCRIPTION
This adds django-rest-framework logs into database. Currently includes a django drf-tracking library.
