### PR TITLE
Functional test python  aasemble django build test

### DIFF
--- a/aasemble/django/apps/buildsvc/models.py
+++ b/aasemble/django/apps/buildsvc/models.py
@@ -1,4 +1,4 @@
-import logging
+ logging
 import os
 import os.path
 import shutil
@@ -251,7 +251,7 @@ class PackageSource(models.Model):
         cmd = ['git', 'ls-remote', self.git_url,
                'refs/heads/%s' % self.branch]
         stdout = run_cmd(cmd)
-        stdout = stdout.decode()
+        #stdout = stdout.decode()
         sha = stdout.split('\t')[0]
 
         if sha == self.last_seen_revision:

--- a/aasemble/django/apps/buildsvc/models.py
+++ b/aasemble/django/apps/buildsvc/models.py
@@ -1,4 +1,4 @@
- logging
+import logging
 import os
 import os.path
 import shutil

--- a/aasemble/django/apps/buildsvc/models.py
+++ b/aasemble/django/apps/buildsvc/models.py
@@ -251,7 +251,7 @@ class PackageSource(models.Model):
         cmd = ['git', 'ls-remote', self.git_url,
                'refs/heads/%s' % self.branch]
         stdout = run_cmd(cmd)
-        #stdout = stdout.decode()
+        stdout = stdout.decode()
         sha = stdout.split('\t')[0]
 
         if sha == self.last_seen_revision:

--- a/aasemble/django/apps/buildsvc/models.py
+++ b/aasemble/django/apps/buildsvc/models.py
@@ -251,6 +251,7 @@ class PackageSource(models.Model):
         cmd = ['git', 'ls-remote', self.git_url,
                'refs/heads/%s' % self.branch]
         stdout = run_cmd(cmd)
+        stdout = stdout.decode()
         sha = stdout.split('\t')[0]
 
         if sha == self.last_seen_revision:

--- a/aasemble/django/apps/buildsvc/tests_functional.py
+++ b/aasemble/django/apps/buildsvc/tests_functional.py
@@ -76,7 +76,7 @@ class RepositoryFunctionalTests(StaticLiveServerTestCase):
         self.delete_package_source()
         self.assertEqual(self.verify_package_source(git_url=git_url), False, 'Package not deleted')
 
-    @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
+    #@override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
     # This tests needs celery so overriding the settings
     def test_build_packages(self):
         '''This test perform a package addtion and check whether a build
@@ -101,7 +101,7 @@ class RepositoryFunctionalTests(StaticLiveServerTestCase):
             if P.git_url == git_url:
                 break
         try:
-            poll_one.apply_async(args=[P.id], expires=60)
+            poll_one(P.id)
         except:
             # Marking Pass even if we got some exception during package build.
             # Our verification is limited to UI inteface. Form UI, It should

--- a/aasemble/django/apps/buildsvc/tests_functional.py
+++ b/aasemble/django/apps/buildsvc/tests_functional.py
@@ -2,11 +2,13 @@ import os
 import re
 
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from django.test.utils import skipIf
+from django.test.utils import override_settings, skipIf
 
 from selenium.webdriver.common import by
 from selenium.webdriver.firefox.webdriver import WebDriver
 from selenium.webdriver.support.ui import Select
+
+from aasemble.django.apps.buildsvc.tasks import poll_one
 
 from aasemble.django.tests import create_session_cookie, create_session_for_given_user
 
@@ -73,6 +75,41 @@ class RepositoryFunctionalTests(StaticLiveServerTestCase):
         self.assertEqual(self.verify_package_source(git_url=git_url), True, 'Package not created')
         self.delete_package_source()
         self.assertEqual(self.verify_package_source(git_url=git_url), False, 'Package not deleted')
+
+    @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
+    # This tests needs celery so overriding the settings
+    def test_build_packages(self):
+        '''This test perform a package addtion and check whether a build
+        started for the same.
+        1. Create a session cookie for given user. We are using a existing
+               user 'brandon' which is already added as fixture.
+        2. Try to create a package.
+        3. Poll the task for package creation. Polling should start the build
+        4. Verify that Building started and it is visible via GUI'''
+        session_cookie = create_session_for_given_user(username='brandon')
+        self.selenium.get(self.live_server_url)
+        self.selenium.add_cookie(session_cookie)
+        # test whether sources page opens after user logs in
+        self.selenium.get('%s%s' % (self.live_server_url, '/buildsvc/sources/'))
+        self.selenium.set_window_size(1024, 768)
+        self.sources_button.click()
+        git_url = "https://github.com/aaSemble/python-aasemble.django.git"
+        self.create_new_package_source(git_url=git_url, branch='master', series='brandon/aasemble')
+        from .models import PackageSource
+        PackageSourceList = PackageSource.objects.all()
+        for P in PackageSourceList:
+            if P.git_url == git_url:
+                break
+        try:
+            poll_one.apply_async(args=[P.id], expires=60)
+        except:
+            # Marking Pass even if we got some exception during package build. Our verification
+            # is limited to UI inteface. Form UI, It should be visible (even if it has just started)
+            pass
+        finally:
+            self.selenium.get('%s%s' % (self.live_server_url, '/buildsvc/sources/'))
+            self.build_button.click()
+            self.assertEqual(self.verify_build_displayed(packageName='python-aasemble.django.git'), True, 'Build not started')
 
     def create_new_package_source(self, git_url, branch, series):
         '''This is the helper method to create
@@ -149,3 +186,18 @@ class RepositoryFunctionalTests(StaticLiveServerTestCase):
     def sources_button(self):
         '''Finds package source button'''
         return self.selenium.find_element(by.By.LINK_TEXT, 'Sources')
+
+    @property
+    def build_button(self):
+        '''Finds package source button'''
+        return self.selenium.find_element(by.By.LINK_TEXT, 'Builds')
+
+    def verify_build_displayed(self, packageName):
+        '''Finds package source button'''
+        try:
+            self.selenium.find_element(by.By.CSS_SELECTOR, "a[href*='%s']" % packageName)
+        except:
+            return False
+        else:
+            return True
+

--- a/aasemble/django/apps/buildsvc/tests_functional.py
+++ b/aasemble/django/apps/buildsvc/tests_functional.py
@@ -96,10 +96,8 @@ class RepositoryFunctionalTests(StaticLiveServerTestCase):
         git_url = "https://github.com/aaSemble/python-aasemble.django.git"
         self.create_new_package_source(git_url=git_url, branch='master', series='brandon/aasemble')
         from .models import PackageSource
-        PackageSourceList = PackageSource.objects.all()
-        for P in PackageSourceList:
-            if P.git_url == git_url:
-                break
+        # Only one package is added with this url
+        P = PackageSource.objects.filter(git_url=git_url)[0]
         try:
             poll_one(P.id)
         except:

--- a/aasemble/django/apps/buildsvc/tests_functional.py
+++ b/aasemble/django/apps/buildsvc/tests_functional.py
@@ -200,4 +200,3 @@ class RepositoryFunctionalTests(StaticLiveServerTestCase):
             return False
         else:
             return True
-

--- a/aasemble/django/apps/buildsvc/tests_functional.py
+++ b/aasemble/django/apps/buildsvc/tests_functional.py
@@ -76,7 +76,7 @@ class RepositoryFunctionalTests(StaticLiveServerTestCase):
         self.delete_package_source()
         self.assertEqual(self.verify_package_source(git_url=git_url), False, 'Package not deleted')
 
-    @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
+    @override_settings(CELERY_ALWAYS_EAGER=True)
     # This tests needs celery so overriding the settings
     def test_build_packages(self):
         '''This test perform a package addtion and check whether a build

--- a/aasemble/django/apps/buildsvc/tests_functional.py
+++ b/aasemble/django/apps/buildsvc/tests_functional.py
@@ -103,8 +103,9 @@ class RepositoryFunctionalTests(StaticLiveServerTestCase):
         try:
             poll_one.apply_async(args=[P.id], expires=60)
         except:
-            # Marking Pass even if we got some exception during package build. Our verification
-            # is limited to UI inteface. Form UI, It should be visible (even if it has just started)
+            # Marking Pass even if we got some exception during package build.
+            # Our verification is limited to UI inteface. Form UI, It should
+            # be visible (even if it has just started)
             pass
         finally:
             self.selenium.get('%s%s' % (self.live_server_url, '/buildsvc/sources/'))

--- a/aasemble/django/apps/buildsvc/tests_functional.py
+++ b/aasemble/django/apps/buildsvc/tests_functional.py
@@ -194,7 +194,7 @@ class RepositoryFunctionalTests(StaticLiveServerTestCase):
         return self.selenium.find_element(by.By.LINK_TEXT, 'Builds')
 
     def verify_build_displayed(self, packageName):
-        '''Finds package source button'''
+        '''Verify whether the Build has started by package name'''
         try:
             self.selenium.find_element(by.By.CSS_SELECTOR, "a[href*='%s']" % packageName)
         except:

--- a/aasemble/django/apps/buildsvc/tests_functional.py
+++ b/aasemble/django/apps/buildsvc/tests_functional.py
@@ -76,6 +76,34 @@ class RepositoryFunctionalTests(StaticLiveServerTestCase):
         self.delete_package_source()
         self.assertEqual(self.verify_package_source(git_url=git_url), False, 'Package not deleted')
 
+    def test_profile_button(self):
+        '''This test verifies the "Profile" button.
+        1. Create a session cookie for given user. We are using a existing
+               user 'brandon' which is already added as fixture.
+        2. Press 'Profile' button.
+        3. Verify page by username'''
+        session_cookie = create_session_for_given_user(username='brandon')
+        self.selenium.get(self.live_server_url)
+        self.selenium.add_cookie(session_cookie)
+        # test whether sources page opens after user logs in
+        self.selenium.get('%s%s' % (self.live_server_url, '/buildsvc/sources/'))
+        self.selenium.set_window_size(1024, 768)
+        self.profile_button.click()
+        self.assertEqual(self.verify_profile_page(username='brandon'), True, "Profile Name not verified")
+
+    def verify_profile_page(self, username):
+        try:
+            self.selenium.find_element(by.By.XPATH, "//dl[@class='dl-horizontal']/dd[contains(text(), %s)]" % username)
+        except:
+            return False
+        else:
+            return True
+
+    @property
+    def profile_button(self):
+        '''Finds package profile button'''
+        return self.selenium.find_element(by.By.LINK_TEXT, 'Profile')
+
     @override_settings(CELERY_ALWAYS_EAGER=True)
     # This tests needs celery so overriding the settings
     def test_build_packages(self):

--- a/aasemble/django/apps/buildsvc/tests_functional.py
+++ b/aasemble/django/apps/buildsvc/tests_functional.py
@@ -76,7 +76,7 @@ class RepositoryFunctionalTests(StaticLiveServerTestCase):
         self.delete_package_source()
         self.assertEqual(self.verify_package_source(git_url=git_url), False, 'Package not deleted')
 
-    #@override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
+    @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
     # This tests needs celery so overriding the settings
     def test_build_packages(self):
         '''This test perform a package addtion and check whether a build

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ django-allauth
 redis
 django-bootstrap3
 github3.py
+docker-py==1.5.0


### PR DESCRIPTION
This test verifies whether a build is started after a "Package Source" detail is submitted from UI.
It fills git_url, branch and series and checks whether build has started on UI after pressing "build" button,
#### 

This pull request also includes a fix found from above test.
Issue:
Split method does not work for binary strings in Python 3.4. The strings starting with prefix b' are considered binary strings on these strings "split" method does not work and gives the error.
"Type str doesn't support the buffer API"

I am facing this issue on Poll method of Model.py
### 

Fix:
def Poll(self):
......
stdout = run_cmd(cmd)
stdout = stdout.decode() # This is fix for python 3.4. This line has no effect for python 2.7
.......
