### PR TITLE
Docker Client version is freezed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ django-allauth
 redis
 django-bootstrap3
 github3.py
+docker-py==1.5.0


### PR DESCRIPTION
due to upgrade in default docker version there were mismatch
in client and server so travis-ci was failing. so same has been
resolved by freezing the client docker version.
