### PR TITLE
Test case added for repository and source

### DIFF
--- a/aasemble/django/apps/api/tests.py
+++ b/aasemble/django/apps/api/tests.py
@@ -269,7 +269,7 @@ class APIv1Tests(APITestCase):
         authenticate(self.client, 'eric')
         # 7 queries: Create transaction, Authenticate, 1 logging entry, count results, fetch results,
         # rollback transaction, log response
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(7):
             response = self.client.get(self.build_list_url)
         self.assertEquals(response.status_code, 200)
         self.assertEquals(response.data['count'], 10)
@@ -303,7 +303,7 @@ class APIv1Tests(APITestCase):
         authenticate(self.client, 'eric')
         # 7 queries: Create transaction, Authenticate, 1 logging entry, count results, fetch results,
         # rollback transaction, log response
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(7):
             response = self.client.get(self.source_list_url)
         self.assertEquals(response.status_code, 200)
         self.assertEquals(response.data['count'], 12)
@@ -315,7 +315,7 @@ class APIv1Tests(APITestCase):
             if res['name'] == 'eric2':
                 # 7 queries: Create transaction, Authenticate, 1 logging entry, count results, fetch results,
                 # rollback transaction, log response
-                with self.assertNumQueries(6):
+                with self.assertNumQueries(7):
                     response = self.client.get(res['sources'])
                 self.assertEquals(response.status_code, 200)
                 self.assertEquals(response.data['count'], 2)

--- a/aasemble/django/apps/api/tests.py
+++ b/aasemble/django/apps/api/tests.py
@@ -410,6 +410,16 @@ class APIv1Tests(APITestCase):
         self.assertEquals(response.status_code, 200)
         self.assertEquals(response.data['repository'], repo.data['results'][1]['self'])
 
+    def test_patch_soure_authoritative_group_member(self):
+        authenticate(self.client, 'dennis')
+        source = self.client.get(self.source_list_url)
+        authenticate(self.client, 'brandon')
+        repo = self.client.get(self.repository_list_url)
+        data = {'repository': repo.data['results'][0]['self']}
+        response = self.client.patch(source.data['results'][0]['self'], data, format='json')
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.data['repository'], repo.data['results'][0]['self'])
+
     def test_patch_source_invalid_data(self):
         source = self.test_create_source()
         data = {'repository': 'invalid repo URL'}
@@ -487,6 +497,13 @@ class APIv1Tests(APITestCase):
         source = self.test_create_source()
         authenticate(self.client, 'george')
         response = self.client.delete(source['self'])
+        self.assertEquals(response.status_code, 204)
+
+    def test_delete_source_authoritative_group_member(self):
+        authenticate(self.client, 'dennis')
+        source = self.client.get(self.source_list_url)
+        authenticate(self.client, 'brandon')
+        response = self.client.delete(source.data['results'][0]['self'])
         self.assertEquals(response.status_code, 204)
 
     def test_delete_source_invalid_token(self):

--- a/aasemble/django/apps/api/tests.py
+++ b/aasemble/django/apps/api/tests.py
@@ -128,7 +128,7 @@ class APIv1Tests(APITestCase):
         self.assertEquals(response.status_code, 404)
         self.assertEquals(response.data, {'detail': 'Not found.'})
 
-    def test_delete_repository_authorative_group_member(self):
+    def test_delete_repository_authoritative_group_member(self):
         authenticate(self.client, 'dennis')
         response = self.client.get(self.repository_list_url)
         authenticate(self.client, 'brandon')
@@ -160,7 +160,7 @@ class APIv1Tests(APITestCase):
         response = self.client.get(response.data['self'])
         self.assertEquals(response.data, expected_result, 'Changes were not persisted')
 
-    def test_patch_repository_authorative_group_member(self):
+    def test_patch_repository_authoritative_group_member(self):
         authenticate(self.client, 'dennis')
         response = self.client.get(self.repository_list_url)
         authenticate(self.client, 'brandon')
@@ -175,7 +175,7 @@ class APIv1Tests(APITestCase):
         response = self.client.patch(repo['self'], data, format='json')
         self.assertNotEquals(response.data['user'], 'testuser2', '"user" read-only field changed')
 
-    def test_patch_repository_authorative_group_member_read_only_field(self):
+    def test_patch_repository_authoritative_group_member_read_only_field(self):
         authenticate(self.client, 'dennis')
         response = self.client.get(self.repository_list_url)
         authenticate(self.client, 'brandon')


### PR DESCRIPTION
 Test case added for repository

following test case added in repository:
1. Delete Repository by user that belong to authoritative group.
2. Patch Repository by user that belong to authoritative group, and field that are read-only.
3. Path repository by user that belong to authoritative group. 
