### PR TITLE
Add tags ui

### DIFF
--- a/aasemble/django/apps/mirrorsvc/forms.py
+++ b/aasemble/django/apps/mirrorsvc/forms.py
@@ -1,6 +1,6 @@
 from django.forms import ModelForm
 
-from aasemble.django.apps.mirrorsvc.models import Mirror, MirrorSet
+from aasemble.django.apps.mirrorsvc.models import Mirror, MirrorSet, Tags
 
 
 class MirrorDefinitionForm(ModelForm):
@@ -13,3 +13,9 @@ class MirrorSetDefinitionForm(ModelForm):
     class Meta:
         model = MirrorSet
         fields = ['name', 'mirrors']
+
+
+class TagDefinitionForm(ModelForm):
+    class Meta:
+        model = Tags
+        fields = ['tag']

--- a/aasemble/django/apps/mirrorsvc/templates/mirrorsvc/html/mirrorset_snapshots.html
+++ b/aasemble/django/apps/mirrorsvc/templates/mirrorsvc/html/mirrorset_snapshots.html
@@ -9,6 +9,8 @@
         <tr>
           <th>Snapshot UUID</th>
           <th>Time Created</th>
+          <th>Tags</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -16,6 +18,12 @@
         <tr>
           <td>{{ snapshot.uuid }}</td>
           <td>{{ snapshot.timestamp }}</td>
+          <td>
+              {% for tag in snapshot.tags.all %}
+                  <a href="{% url "mirrorsvc:snapshot_add_tag" snapshot_uuid=snapshot.uuid tag_id=tag.id %}">{{ tag.tag }} </a>
+              {% endfor %}
+          </td>
+          <td><a class="btn btn-primary" href="{% url "mirrorsvc:snapshot_add_tag" snapshot_uuid=snapshot.uuid tag_id='new' %}" role="button">{% bootstrap_icon "plus" %} Add tag</a></td>
         </tr>
       {% endfor %}
       </tbody>

--- a/aasemble/django/apps/mirrorsvc/templates/mirrorsvc/html/snapshots.html
+++ b/aasemble/django/apps/mirrorsvc/templates/mirrorsvc/html/snapshots.html
@@ -23,7 +23,7 @@
           <td>{{ snapshot.uuid }}</td>
           <td>{{ snapshot.timestamp }}</td>
           <td>
-              {% for tag in snapshot.tags %}
+              {% for tag in snapshot.tags.all %}
                   <a href="{% url "mirrorsvc:snapshot_add_tag" snapshot_uuid=snapshot.uuid tag_id=tag.id %}">{{ tag.tag }} </a>
               {% endfor %}
           </td>

--- a/aasemble/django/apps/mirrorsvc/templates/mirrorsvc/html/snapshots.html
+++ b/aasemble/django/apps/mirrorsvc/templates/mirrorsvc/html/snapshots.html
@@ -11,6 +11,8 @@
           <th>Mirror-Set Name</th>
           <th>Snapshot UUID</th>
           <th>Time Created</th>
+          <th>Tags</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -20,6 +22,12 @@
           <td>{{ snapshot.mirrorset.name }}</td>
           <td>{{ snapshot.uuid }}</td>
           <td>{{ snapshot.timestamp }}</td>
+          <td>
+              {% for tag in snapshot.tags %}
+                  <a href="{% url "mirrorsvc:snapshot_add_tag" snapshot_uuid=snapshot.uuid tag_id=tag.id %}">{{ tag.tag }} </a>
+              {% endfor %}
+          </td>
+          <td><a class="btn btn-primary" href="{% url "mirrorsvc:snapshot_add_tag" snapshot_uuid=snapshot.uuid tag_id='new' %}" role="button">{% bootstrap_icon "plus" %} Add tag</a></td>
         </tr>
       {% endfor %}
       </tbody>

--- a/aasemble/django/apps/mirrorsvc/templates/mirrorsvc/html/tag_definition.html
+++ b/aasemble/django/apps/mirrorsvc/templates/mirrorsvc/html/tag_definition.html
@@ -1,0 +1,25 @@
+{% extends 'aasemble/base.html' %}
+{% load bootstrap3 %}
+{% block title %}
+    {% if tag_id != 'new' %}
+        Edit Tag
+    {% else %}
+        Add new Tag
+    {% endif %}
+{% endblock %}
+{% block aasemble_content %}
+<form action="{% url "mirrorsvc:snapshot_add_tag" snapshot_uuid=snapshot_uuid tag_id=tag_id %}" method="post">
+    {% csrf_token %}
+    {% bootstrap_form form layout='inline' %}
+    {% buttons %}
+        <button type="submit" class="btn btn-primary">
+            {% bootstrap_icon "star" %} Submit
+        </button>
+        {% if tag_id != 'new' %}
+            <button type="submit" class="btn btn-danger" name="delete" value="delete">
+                 Delete
+            </button>
+        {% endif %}
+    {% endbuttons %}
+{% endblock %}
+

--- a/aasemble/django/apps/mirrorsvc/urls.py
+++ b/aasemble/django/apps/mirrorsvc/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     url(r'^mirrors/(?P<mirror_uuid>[^/]+)/refresh/', aasemble.django.apps.mirrorsvc.views.refresh_mirror_with_uuid,
         name='mirror_refresh'),  # Added before mirrors/ to override next line
     url(r'^mirrors/', aasemble.django.apps.mirrorsvc.views.mirrors, name='mirrors'),
+    url(r'^snapshots/(?P<snapshot_uuid>[^/]+)/tags/(?P<tag_id>[^/]+|new)', aasemble.django.apps.mirrorsvc.views.snapshot_add_tag, name='snapshot_add_tag'),
     url(r'^snapshots/', aasemble.django.apps.mirrorsvc.views.snapshots, name='snapshots'),
     url(r'^mirrorsets/(?P<uuid>[^/]+|new)/$', aasemble.django.apps.mirrorsvc.views.mirrorset_definition,
         name='mirrorset_definition'),

--- a/aasemble/django/apps/mirrorsvc/views.py
+++ b/aasemble/django/apps/mirrorsvc/views.py
@@ -121,7 +121,7 @@ def snapshot_add_tag(request, snapshot_uuid, tag_id):
         form = get_tag_definition_form(request, instance=tag)
 
     return render(request, 'mirrorsvc/html/tag_definition.html',
-                  {'form': form, 'snapshot_uuid': snapshot.uuid})
+                  {'form': form, 'snapshot_uuid': snapshot.uuid, 'tag_id': tag_id})
 
 
 @login_required

--- a/aasemble/django/apps/mirrorsvc/views.py
+++ b/aasemble/django/apps/mirrorsvc/views.py
@@ -1,10 +1,10 @@
 from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
-from django.http import HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 
-from .forms import MirrorDefinitionForm, MirrorSetDefinitionForm
-from .models import Mirror, MirrorSet, Snapshot
+from .forms import MirrorDefinitionForm, MirrorSetDefinitionForm, TagDefinitionForm
+from .models import Mirror, MirrorSet, Snapshot, Tags
 
 
 def get_mirror_definition_form(request, *args, **kwargs):
@@ -86,6 +86,42 @@ def snapshots(request):
     snapshots = Snapshot.objects.filter(mirrorset__in=MirrorSet.lookup_by_user(request.user)).order_by('timestamp')
     return render(request, 'mirrorsvc/html/snapshots.html',
                   {'snapshots': snapshots})
+
+
+def get_tag_definition_form(request, *args, **kwargs):
+    form = TagDefinitionForm(*args, **kwargs)
+    return form
+
+
+@login_required
+def snapshot_add_tag(request, snapshot_uuid, tag_id):
+    snapshot = Snapshot.objects.get(uuid=snapshot_uuid)
+    if not snapshot.user_can_modify(request.user):
+        return HttpResponse("You don't have access rights to add a tag to this snapshot")
+
+    if tag_id == 'new':
+        tag = None
+    else:
+        tag = Tags.objects.get(pk=tag_id)
+
+    if request.method == 'POST':
+        form = get_tag_definition_form(request, request.POST, instance=tag)
+
+        if tag is not None and request.POST.get('delete', '') == 'delete':
+            tag.delete()
+            return HttpResponseRedirect(reverse('mirrorsvc:snapshots'))
+
+        if form.is_valid():
+            new_tag = form.save(commit=False)
+            new_tag.snapshot = snapshot
+            new_tag.save()
+            print("new_tag saved")
+            return HttpResponseRedirect(reverse('mirrorsvc:snapshots'))
+    else:
+        form = get_tag_definition_form(request, instance=tag)
+
+    return render(request, 'mirrorsvc/html/tag_definition.html',
+                  {'form': form, 'snapshot_uuid': snapshot.uuid})
 
 
 @login_required

--- a/aasemble/django/apps/mirrorsvc/views.py
+++ b/aasemble/django/apps/mirrorsvc/views.py
@@ -65,7 +65,6 @@ def mirrorset_definition(request, uuid):
             new_mirrorset = form.save(commit=False)
             new_mirrorset.owner = request.user
             new_mirrorset.save()
-            print("new_mirrorset saved")
             return HttpResponseRedirect(reverse('mirrorsvc:mirrorsets'))
     else:
         form = get_mirrorset_definition_form(request, instance=mirrorset)
@@ -115,7 +114,6 @@ def snapshot_add_tag(request, snapshot_uuid, tag_id):
             new_tag = form.save(commit=False)
             new_tag.snapshot = snapshot
             new_tag.save()
-            print("new_tag saved")
             return HttpResponseRedirect(reverse('mirrorsvc:snapshots'))
     else:
         form = get_tag_definition_form(request, instance=tag)


### PR DESCRIPTION
Now user can add and edit snapshot tags from the UI, both snapshots page and mirrorsets-snapshots page.
Fixes #180.
