### PR TITLE
Destroy virtualenv cache on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 dependencies:
   override:
+    - rm -rf virtuelenvs
     - pip install -U pip
     - pip install -U "Django<1.9"
     - pip install -r requirements.txt


### PR DESCRIPTION
I'd much rather wait an additional couple of seconds for correct test
results than deal with these constant false negatives.
