### PR TITLE
Make use of webhooks configurable

### DIFF
--- a/aasemble/django/apps/buildsvc/models.py
+++ b/aasemble/django/apps/buildsvc/models.py
@@ -359,6 +359,9 @@ class PackageSource(models.Model):
         return (parts[0], parts[1])
 
     def register_webhook(self):
+        if not getattr(settings, 'AASEMBLE_BUILDSVC_USE_WEBHOOKS', True):
+            return True
+
         if self.webhook_registered:
             return True
 

--- a/aasemble/django/apps/buildsvc/tests.py
+++ b/aasemble/django/apps/buildsvc/tests.py
@@ -277,6 +277,18 @@ class PackageSourceTestCase(TestCase):
         self.assertRaises(NotAValidGithubRepository, ps.github_owner_repo)
 
     @mock.patch('github3.GitHub')
+    @override_settings(AASEMBLE_BUILDSVC_USE_WEBHOOKS=False)
+    def test_register_webhook_disabled(self, GitHub):
+        ps = PackageSource.objects.create(series_id=1,
+                                          git_url='https://github.com/owner/repo',
+                                          branch='master',
+                                          last_built_name='something')
+
+        ps.register_webhook()
+
+        GitHub.assert_not_called()
+
+    @mock.patch('github3.GitHub')
     @override_settings(GITHUB_WEBHOOK_URL='https://example.com/api/github/')
     def test_register_webhook(self, GitHub):
         ps = PackageSource.objects.create(series_id=1,


### PR DESCRIPTION
Add a setting (`AASEMBLE_BUILDSVC_USE_WEBHOOKS`) allowing installations
to opt out of using webhooks and rely entirely on Git polling.
