### PR TITLE
Replace hardcoded buildsvc repo url

### DIFF
--- a/aasemble/django/apps/api/tests.py
+++ b/aasemble/django/apps/api/tests.py
@@ -89,8 +89,8 @@ class APIv1Tests(APITestCase):
         self.assertTrue(response.data['self'].startswith('http://testserver' + self.repository_list_url), response.data['self'])
         expected_result = {'external_dependencies': response.data['self'] + 'external_dependencies/',
                            'name': 'testrepo',
-                           'binary_source_list': 'deb http://127.0.0.1:8000/apt/%s/testrepo aasemble main' % (user,),
-                           'source_source_list': 'deb-src http://127.0.0.1:8000/apt/%s/testrepo aasemble main' % (user,),
+                           'binary_source_list': 'deb %s/%s/testrepo aasemble main' % (settings.BUILDSVC_REPOS_BASE_URL, user,),
+                           'source_source_list': 'deb-src %s/%s/testrepo aasemble main' % (settings.BUILDSVC_REPOS_BASE_URL, user,),
                            'self': response.data['self'],
                            'sources': response.data['self'] + 'sources/',
                            'user': user,
@@ -155,8 +155,8 @@ class APIv1Tests(APITestCase):
         self.assertEquals(response.data['self'], repo['self'], '"self" attribute changed')
         expected_result = {'external_dependencies': response.data['self'] + 'external_dependencies/',
                            'name': 'testrepo2',
-                           'binary_source_list': 'deb http://127.0.0.1:8000/apt/eric/testrepo2 aasemble main',
-                           'source_source_list': 'deb-src http://127.0.0.1:8000/apt/eric/testrepo2 aasemble main',
+                           'binary_source_list': 'deb %s/eric/testrepo2 aasemble main' % (settings.BUILDSVC_REPOS_BASE_URL,),
+                           'source_source_list': 'deb-src %s/eric/testrepo2 aasemble main' % (settings.BUILDSVC_REPOS_BASE_URL,),
                            'self': response.data['self'],
                            'sources': response.data['self'] + 'sources/',
                            'user': 'eric',


### PR DESCRIPTION
Now the tests take the repo url from settings. This should fix an issue with tests failing while running on a corporate server.
