### PR TITLE
Save new repo before exporting

### DIFF
--- a/aasemble/django/apps/buildsvc/models.py
+++ b/aasemble/django/apps/buildsvc/models.py
@@ -169,8 +169,8 @@ class Repository(models.Model):
         self.export()
 
     def save(self, *args, **kwargs):
-        tasks.export.delay(self.id)
         super(Repository, self).save(*args, **kwargs)
+        tasks.export.delay(self.id)
 
     @property
     def base_url(self):


### PR DESCRIPTION
Now a new repo is first saved and then exported. Currently new repos aren't exported as the repo ID doesn't exist for the export task.

```
[2015-12-27 18:33:48,323: ERROR/MainProcess] Task aasemble.django.apps.buildsvc.tasks.export[13ebeeb0-52ca-42fe-9e13-dc398e16341c] raised unexpected: DoesNotExist('Repository matching query does not exist.',)
Traceback (most recent call last):
  File "/var/lib/pkgbuilder/venv/local/lib/python2.7/site-packages/celery/app/trace.py", line 240, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/var/lib/pkgbuilder/venv/local/lib/python2.7/site-packages/celery/app/trace.py", line 438, in __protected_call__
    return self.run(*args, **kwargs)
  File "/var/lib/pkgbuilder/aasemble/django/apps/buildsvc/tasks.py", line 14, in export
    r = Repository.objects.get(id=repository_id)
  File "/var/lib/pkgbuilder/venv/local/lib/python2.7/site-packages/django/db/models/manager.py", line 122, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/var/lib/pkgbuilder/venv/local/lib/python2.7/site-packages/django/db/models/query.py", line 387, in get
    self.model._meta.object_name
Exception: Repository matching query does not exist.
```
