### PR TITLE
Delay snapshot creation a little bit

### DIFF
--- a/aasemble/django/apps/mirrorsvc/models.py
+++ b/aasemble/django/apps/mirrorsvc/models.py
@@ -159,7 +159,7 @@ class Snapshot(models.Model):
         super(Snapshot, self).save(*args, **kwargs)
 
         if perform_snapshot:
-            tasks.perform_snapshot.delay(self.id)
+            tasks.perform_snapshot.apply_async((self.id,), countdown=5)
 
     def perform_snapshot(self):
         self.sync_dists()

--- a/aasemble/django/apps/mirrorsvc/tests.py
+++ b/aasemble/django/apps/mirrorsvc/tests.py
@@ -15,7 +15,7 @@ class SnapshotTestCase(TestCase):
         ms.mirrors.add(m)
         s = Snapshot.objects.create(mirrorset=ms)
         Tags.objects.create(snapshot=s, tag='test')
-        perform_snapshot.delay.assert_called_with(s.id)
+        perform_snapshot.apply_async.assert_called_with((s.id,), countdown=5)
 
     @mock.patch('aasemble.django.apps.mirrorsvc.models.Snapshot.sync_dists')
     @mock.patch('aasemble.django.apps.mirrorsvc.models.Snapshot.symlink_pool')


### PR DESCRIPTION
When drf-tracking is in use, the view is handled in a transaction. This
means the Snapshot isn't committed until after the view is done (and it
has been logged). Sometimes, the celery task runs before, and then it
fails to find the Snapshot.

Delay the task a tiny bit to overcome this. It's a bit racy, but it's
the best we have right now.
