### PR TITLE
Model instance methods are not available during migration

### DIFF
--- a/aasemble/django/apps/buildsvc/migrations/0019_import_key_data.py
+++ b/aasemble/django/apps/buildsvc/migrations/0019_import_key_data.py
@@ -4,12 +4,19 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 
+from aasemble.django.utils import run_cmd
+
 
 def import_key_data(apps, schema_editor):
     Repository = apps.get_model("buildsvc", "Repository")
     for repo in Repository.objects.all():
-        repo.key_data = repo._key_data()
+        repo.key_data = key_data(repo)
         repo.save()
+
+
+def key_data(repository):
+    if repository.key_id:
+        return run_cmd(['gpg', '-a', '--export', repository.key_id])
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Copy the code from the models.
