### PR TITLE
add-UI-to-enable-source-rep

### DIFF
--- a/aasemble/django/apps/buildsvc/templates/buildsvc/html/sources.html
+++ b/aasemble/django/apps/buildsvc/templates/buildsvc/html/sources.html
@@ -12,7 +12,8 @@
           <th>Branch</th>
           <th>Destination APT repo</th>
           <th>Last built commit</th>
-          <th>Rebuild</th>
+          <th>Status</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -29,7 +30,18 @@
               <td><a href="{{ last_commit_url }}">{{ source.last_seen_revision }}</a></td>
               {% endwith %}
           {% endif %}
-          <td><small><center><a href="{% url "buildsvc:rebuild" source_id=source.id %}">{% bootstrap_icon "repeat" %}</a></center></small></td>
+          <td>
+              {% if source.disabled %}
+                  Disabled
+              {% else %}
+                  Enabled
+              {% endif %}
+          </td>
+          <td>
+              {% if source.disabled %}
+                  <small><a href="{% url "buildsvc:enable_source_repo" source_id=source.id %}" role="button">{% bootstrap_icon "repeat" %} Enable</a></small>
+              {% endif %}
+          </td>
         </tr>
         {% endfor %}
       </tbody>

--- a/aasemble/django/apps/buildsvc/urls.py
+++ b/aasemble/django/apps/buildsvc/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import url
 import aasemble.django.apps.buildsvc.views
 
 urlpatterns = [
+    url(r'^sources/(?P<source_id>\d+)/enable/', aasemble.django.apps.buildsvc.views.enable_source_repo, name='enable_source_repo'),
     url(r'^sources/(?P<source_id>\d+|new)/', aasemble.django.apps.buildsvc.views.package_source, name='package_source'),
     url(r'^sources/', aasemble.django.apps.buildsvc.views.sources, name='sources'),
     url(r'^repositories/', aasemble.django.apps.buildsvc.views.repositories, name='repositories'),


### PR DESCRIPTION
Now we can re-enable a disabled source repo from the sources view. This will help avoid directly modifying the database to re-enable a repo.
Fixes #263. 
