### PR TITLE
Add Executor abstraction

### DIFF
--- a/aasemble/django/apps/buildsvc/executors.py
+++ b/aasemble/django/apps/buildsvc/executors.py
@@ -1,0 +1,120 @@
+import os
+import os.path
+
+from django.conf import settings
+
+from libcloud.compute.providers import get_driver
+from libcloud.compute.types import Provider
+
+from aasemble.django.utils import run_cmd, ssh_get, ssh_run_cmd
+
+
+class Local(object):
+    def __init__(self, name):
+        pass
+
+    def run_cmd(self, *args, **kwargs):
+        return run_cmd(*args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+
+class GCENode(object):
+    def __init__(self, name):
+        self.name = name
+        self._connection = None
+
+    @property
+    def connection(self):
+        if self._connection is None:
+            driver = get_driver(Provider.GCE)
+            self._connection = driver(settings.AASEMBLE_BUILDSVC_GCE_SERVICE_ACCOUNT,
+                                      settings.AASEMBLE_BUILDSVC_GCE_KEY_FILE,
+                                      project=settings.AASEMBLE_BUILDSVC_GCE_PROJECT)
+        return self._connection
+
+    @property
+    def _zone(self, settings=settings):
+        return getattr(settings, 'AASEMBLE_BUILDSVC_GCE_ZONE', 'us-central1-f')
+
+    @property
+    def _machine_type_short(self):
+        return getattr(settings, 'AASEMBLE_BUILDSVC_GCE_MACHINE_TYPE', 'n1-standard-4')
+
+    @property
+    def _ssh_public_key_file(self):
+        default_ssh_public_key_file = os.path.expanduser('~/.ssh/id_rsa.pub')
+        return getattr(settings, 'AASEMBLE_BUILDSVC_PUBLIC_KEY', default_ssh_public_key_file)
+
+    @property
+    def _ssh_public_key_data(self):
+        with open(self._ssh_public_key_file, 'r') as fp:
+            return fp.read()
+
+    @property
+    def _source_disk_image(self):
+        return settings.AASEMBLE_BUILDSVC_GCE_IMAGE
+
+    @property
+    def _startup_script(self):
+        with open(os.path.join(os.path.dirname(__file__), 'startup-script.sh'), 'r') as fp:
+            return fp.read()
+
+    @property
+    def _disk_size(self, settings=settings):
+        return getattr(settings, 'AASEMBLE_BUILDSVC_GCE_DISK_SIZE', 100)
+
+    @property
+    def _disks(self):
+        return [{'boot': True,
+                 'autoDelete': True,
+                 'initializeParams': {
+                     'sourceImage': self._source_disk_image,
+                     'diskType': 'zones/%s/diskTypes/pd-ssd' % (self._zone,),
+                     'diskSizeGb': self._disk_size}}]
+
+    @property
+    def _metadata(self):
+        return {'startup-script': self._startup_script,
+                'sshKeys': 'ubuntu:' + self._ssh_public_key_data}
+
+    def launch(self):
+        self.node = self.connection.create_node(name=self.name,
+                                                size=self._machine_type_short,
+                                                image=None,
+                                                location=self._zone,
+                                                ex_disks_gce_struct=self._disks,
+                                                ex_metadata=self._metadata)
+
+    @property
+    def _ssh_connect_string(self):
+        return 'ubuntu@%s' % (self.node.public_ips[0],)
+
+    def run_cmd(self, *args, **kwargs):
+        return ssh_run_cmd(self._ssh_connect_string, *args, remote_cwd='workspace', **kwargs)
+
+    def get(self, shell_pattern, destdir):
+        ssh_get(self._ssh_connect_string, 'workspace/{}'.format(shell_pattern), destdir)
+
+    def destroy(self):
+        self.node.destroy()
+
+    def __enter__(self):
+        self.launch()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.destroy()
+
+
+def get_executor(name=None, settings=settings):
+    if name is None:
+        name = getattr(settings, 'AASEMBLE_BUILDSVC_EXECUTOR', 'Local')
+    return globals()[name]

--- a/aasemble/django/apps/buildsvc/models.py
+++ b/aasemble/django/apps/buildsvc/models.py
@@ -358,10 +358,7 @@ class PackageSource(models.Model):
         br = BuildRecord(source=self, build_counter=self.build_counter, sha=self.last_seen_revision)
         br.save()
 
-        if getattr(settings, 'AASEMBLE_BUILDSVC_GCE_BUILD_NODES', False):
-            executor_class = executors.GCENode
-        else:
-            executor_class = executors.Local
+        executor_class = executors.get_executor()
 
         with executor_class('br-%s' % (br.uuid,)) as executor:
             executor.run_cmd(['timeout', '300', 'bash', '-c', 'while aasemble-pkgbuild --help; do sleep 5; done'])

--- a/aasemble/django/apps/buildsvc/models.py
+++ b/aasemble/django/apps/buildsvc/models.py
@@ -361,7 +361,7 @@ class PackageSource(models.Model):
         executor_class = executors.get_executor()
 
         with executor_class('br-%s' % (br.uuid,)) as executor:
-            executor.run_cmd(['timeout', '300', 'bash', '-c', 'while aasemble-pkgbuild --help; do sleep 5; done'])
+            executor.run_cmd(['timeout', '300', 'bash', '-c', 'while ! aasemble-pkgbuild --help; do sleep 5; done'])
             tmpdir = tempfile.mkdtemp()
             try:
                 site = Site.objects.get_current()

--- a/aasemble/django/apps/buildsvc/models.py
+++ b/aasemble/django/apps/buildsvc/models.py
@@ -20,14 +20,11 @@ from django.utils.timezone import now
 
 import github3
 
-from libcloud.compute.providers import get_driver
-from libcloud.compute.types import Provider
-
 from six.moves.urllib.parse import urlparse
 
-from . import tasks
+from . import executors, tasks
 from ...exceptions import CommandFailed
-from ...utils import ensure_dir, recursive_render, run_cmd, ssh_get, ssh_run_cmd
+from ...utils import ensure_dir, recursive_render, run_cmd
 
 LOG = logging.getLogger(__name__)
 
@@ -80,82 +77,6 @@ def get_repo_driver(repository):
     driver_name = getattr(settings, 'BUILDSVC_REPODRIVER', 'aasemble.django.apps.buildsvc.models.RepreproDriver')
     driver = import_string(driver_name)
     return driver(repository)
-
-
-class GCENode(object):
-    def __init__(self, name):
-        self.driver = get_driver(Provider.GCE)
-        self.connection = self.driver(settings.AASEMBLE_BUILDSVC_GCE_SERVICE_ACCOUNT,
-                                      settings.AASEMBLE_BUILDSVC_GCE_KEY_FILE,
-                                      project=settings.AASEMBLE_BUILDSVC_GCE_PROJECT)
-        self.name = name
-
-    @property
-    def zone(self, settings=settings):
-        return getattr(settings, 'AASEMBLE_BUILDSVC_GCE_ZONE', 'us-central1-f')
-
-    @property
-    def machine_type_short(self, settings=settings):
-        return getattr(settings, 'AASEMBLE_BUILDSVC_GCE_MACHINE_TYPE', 'n1-standard-4')
-
-    @property
-    def ssh_public_key_file(self, settings=settings):
-        default_ssh_public_key_file = os.path.expanduser('~/.ssh/id_rsa.pub')
-        return getattr(settings, 'AASEMBLE_BUILDSVC_PUBLIC_KEY', default_ssh_public_key_file)
-
-    @property
-    def ssh_public_key_data(self):
-        with open(self.ssh_public_key_file, 'r') as fp:
-            return fp.read()
-
-    @property
-    def source_disk_image(self, settings=settings):
-        return settings.AASEMBLE_BUILDSVC_GCE_IMAGE
-        return self.connection.ex_get_image(settings.AASEMBLE_BUILDSVC_GCE_IMAGE)
-
-    @property
-    def startup_script(self):
-        with open(os.path.join(os.path.dirname(__file__), 'startup-script.sh'), 'r') as fp:
-            return fp.read()
-
-    @property
-    def disk_size(self, settings=settings):
-        return getattr(settings, 'AASEMBLE_BUILDSVC_GCE_DISK_SIZE', 100)
-
-    @property
-    def disks(self):
-        return [{'boot': True,
-                 'autoDelete': True,
-                 'initializeParams': {
-                     'sourceImage': self.source_disk_image,
-                     'diskType': 'zones/%s/diskTypes/pd-ssd' % (self.zone,),
-                     'diskSizeGb': self.disk_size}}]
-
-    @property
-    def metadata(self):
-        return {'startup-script': self.startup_script,
-                'sshKeys': 'ubuntu:' + self.ssh_public_key_data}
-
-    def launch(self):
-        self.node = self.connection.create_node(name=self.name,
-                                                size=self.machine_type_short,
-                                                image=None,
-                                                location=self.zone,
-                                                ex_disks_gce_struct=self.disks,
-                                                ex_metadata=self.metadata)
-
-    @property
-    def ssh_connect_string(self):
-        return 'ubuntu@%s' % (self.node.public_ips[0],)
-
-    def run_cmd(self, *args, **kwargs):
-        return ssh_run_cmd(self.ssh_connect_string, *args, remote_cwd='workspace', **kwargs)
-
-    def get(self, shell_pattern, destdir):
-        ssh_get(self.ssh_connect_string, 'workspace/{}'.format(shell_pattern), destdir)
-
-    def destroy(self):
-        self.node.destroy()
 
 
 @python_2_unicode_compatible
@@ -438,61 +359,56 @@ class PackageSource(models.Model):
         br.save()
 
         if getattr(settings, 'AASEMBLE_BUILDSVC_GCE_BUILD_NODES', False):
-            node = GCENode('br-%s' % (br.uuid,))
-            node.launch()
-            run_cmd_real = node.run_cmd
-            run_cmd_real(['timeout', '300', 'bash', '-c', 'while ! which aasemble-pkgbuild; do sleep 5; done'])
+            executor_class = executors.GCENode
         else:
-            run_cmd_real = run_cmd
-            node = None
+            executor_class = executors.Local
 
-        tmpdir = tempfile.mkdtemp()
-        try:
-            site = Site.objects.get_current()
-            br_url = '%s://%s%s' % (getattr(settings, 'AASEMBLE_DEFAULT_PROTOCOL', 'http'),
-                                    site.domain, br.get_absolute_url())
+        with executor_class('br-%s' % (br.uuid,)) as executor:
+            executor.run_cmd(['timeout', '300', 'bash', '-c', 'while aasemble-pkgbuild --help; do sleep 5; done'])
+            tmpdir = tempfile.mkdtemp()
+            try:
+                site = Site.objects.get_current()
+                br_url = '%s://%s%s' % (getattr(settings, 'AASEMBLE_DEFAULT_PROTOCOL', 'http'),
+                                        site.domain, br.get_absolute_url())
 
-            run_cmd_real(['aasemble-pkgbuild', 'checkout', br_url], cwd=tmpdir, logger=br.logger)
-            version = run_cmd_real(['aasemble-pkgbuild', 'version', br_url], cwd=tmpdir, logger=br.logger)
-            name = run_cmd_real(['aasemble-pkgbuild', 'name', br_url], cwd=tmpdir, logger=br.logger)
+                executor.run_cmd(['aasemble-pkgbuild', 'checkout', br_url], cwd=tmpdir, logger=br.logger)
+                version = executor.run_cmd(['aasemble-pkgbuild', 'version', br_url], cwd=tmpdir, logger=br.logger)
+                name = executor.run_cmd(['aasemble-pkgbuild', 'name', br_url], cwd=tmpdir, logger=br.logger)
 
-            br.version = version
-            br.save()
+                br.version = version
+                br.save()
 
-            self.last_built_version = version
-            self.last_built_name = name
-            self.save()
+                self.last_built_version = version
+                self.last_built_name = name
+                self.save()
 
-            build_cmd = ['aasemble-pkgbuild']
+                build_cmd = ['aasemble-pkgbuild']
 
-            if hasattr(settings, 'AASEMBLE_BUILDSVC_BUILDER_HTTP_PROXY'):
-                if settings.AASEMBLE_BUILDSVC_BUILDER_HTTP_PROXY:
-                    build_cmd += ['--proxy', settings.AASEMBLE_BUILDSVC_BUILDER_HTTP_PROXY]
+                if hasattr(settings, 'AASEMBLE_BUILDSVC_BUILDER_HTTP_PROXY'):
+                    if settings.AASEMBLE_BUILDSVC_BUILDER_HTTP_PROXY:
+                        build_cmd += ['--proxy', settings.AASEMBLE_BUILDSVC_BUILDER_HTTP_PROXY]
 
-            build_cmd += ['--fullname', settings.BUILDSVC_DEBFULLNAME]
-            build_cmd += ['--email', settings.BUILDSVC_DEBEMAIL]
-            build_cmd += ['--parallel', str(getattr(settings, 'AASEMBLE_BUILDSVC_DEFAULT_PARALLEL', 1))]
+                build_cmd += ['--fullname', settings.BUILDSVC_DEBFULLNAME]
+                build_cmd += ['--email', settings.BUILDSVC_DEBEMAIL]
+                build_cmd += ['--parallel', str(getattr(settings, 'AASEMBLE_BUILDSVC_DEFAULT_PARALLEL', 1))]
 
-            build_cmd += ['build', br_url]
+                build_cmd += ['build', br_url]
 
-            run_cmd_real(build_cmd, cwd=tmpdir, logger=br.logger)
+                executor.run_cmd(build_cmd, cwd=tmpdir, logger=br.logger)
 
-            if node:
-                node.get('*.*', tmpdir)
+                executor.get('*.*', tmpdir)
 
-            br.build_finished = now()
-            br.save()
+                br.build_finished = now()
+                br.save()
 
-            changes_files = filter(lambda s: s.endswith('.changes'), os.listdir(tmpdir))
+                changes_files = filter(lambda s: s.endswith('.changes'), os.listdir(tmpdir))
 
-            for changes_file in changes_files:
-                self.series.process_changes(os.path.join(tmpdir, changes_file))
+                for changes_file in changes_files:
+                    self.series.process_changes(os.path.join(tmpdir, changes_file))
 
-            self.series.export()
-        finally:
-            shutil.rmtree(tmpdir)
-            if node:
-                node.destroy()
+                self.series.export()
+            finally:
+                shutil.rmtree(tmpdir)
 
     def delete_on_filesystem(self):
         if self.last_built_name:


### PR DESCRIPTION
This cleans up the build method of PackageSources and should make testing
of it easier, too.
