### PR TITLE
fix broken key

### DIFF
--- a/aasemble/django/apps/buildsvc/pkgbuild/__init__.py
+++ b/aasemble/django/apps/buildsvc/pkgbuild/__init__.py
@@ -222,7 +222,7 @@ class PackageBuilder(object):
 
     @property
     def name(self):
-        return self.build_record['source']['git_url'].split('/')[-1].replace('_', '-')
+        return self.build_record['source']['git_repository'].split('/')[-1].replace('_', '-')
 
     @property
     def package_version(self):


### PR DESCRIPTION
https://github.com/aaSemble/python-aasemble.django/pull/294 tries to fix https://github.com/aaSemble/python-aasemble.django/issues/293 but the fix uses git_url.

git_url is serialized as git_repository leading to broken name..

This changes the git_url to git_repository

```
modified:   buildsvc/pkgbuild/__init__.py
```

This fixes https://github.com/aaSemble/python-aasemble.django/issues/297
