### PR TITLE
Show only 6 chars of the commit id

### DIFF
--- a/aasemble/django/apps/buildsvc/templates/buildsvc/html/sources.html
+++ b/aasemble/django/apps/buildsvc/templates/buildsvc/html/sources.html
@@ -39,7 +39,7 @@
                   None
               {% else %}
                   {% with source.git_url|add:"/commit/"|add:source.last_seen_revision as last_commit_url %}
-                  <a href="{{ last_commit_url }}">{{ source.last_seen_revision }}</a>
+                  <a href="{{ last_commit_url }}">{{ source.last_seen_revision|truncatechars:9 }}</a>
                   {% endwith %}
               {% endif %}
           </td>


### PR DESCRIPTION
Not much use showing the entire sha,
causes unrequired h-scroll
closes https://github.com/aaSemble/python-aasemble.django/issues/274
