### PR TITLE
Improve build node launch handling

### DIFF
--- a/aasemble/django/apps/buildsvc/models/build_record.py
+++ b/aasemble/django/apps/buildsvc/models/build_record.py
@@ -96,12 +96,16 @@ class BuildRecord(models.Model):
             old = BuildRecord.objects.get(pk=self.pk)
             if not old.build_finished:
                 with open(self.final_log_path(), 'wb') as outfp:
-                    with open(self.temporary_log_path(), 'rb') as infp:
-                        while True:
-                            buf = infp.read(4096)
-                            if not buf:
-                                break
-                            outfp.write(buf)
+                    try:
+                        with open(self.temporary_log_path(), 'rb') as infp:
+                            while True:
+                                buf = infp.read(4096)
+                                if not buf:
+                                    break
+                                outfp.write(buf)
+                    except:
+                        # If this doesn't work out, we should still save the record
+                        pass
         return super(BuildRecord, self).save(*args, **kwargs)
 
     def final_log_path(self):

--- a/aasemble/django/apps/buildsvc/models/package_source.py
+++ b/aasemble/django/apps/buildsvc/models/package_source.py
@@ -134,7 +134,7 @@ class PackageSource(models.Model):
                 br.state = BuildRecord.BUILDING
                 br.save()
 
-                executor.run_cmd(['timeout', '300', 'bash', '-c', 'while ! aasemble-pkgbuild --help; do sleep 5; done'])
+                executor.run_cmd(['timeout', '500', 'bash', '-c', 'while ! aasemble-pkgbuild --help; do sleep 20; done'], logger=br.logger)
                 tmpdir = tempfile.mkdtemp()
                 try:
                     site = Site.objects.get_current()


### PR DESCRIPTION
Wait a couple of minutes longer for build node to be ready.
Log the progress.
Ensure that builds are correctly marked as failed if this does not work out.

Fixes #306
