### PR TITLE
Update Install procedure and freeze amqp version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ pycrypto
 paramiko
 python-gnupg
 anyjson
-amqp
+amqp==1.4.9


### PR DESCRIPTION
This patch
- Adds details regarding celery, docker, parameters etc that are required for
  getting a local install running
- Pins amqp to 1.4.9
